### PR TITLE
Always use utf8 encoding in mysqlWriteTable.

### DIFF
--- a/R/MySQLSupport.R
+++ b/R/MySQLSupport.R
@@ -621,11 +621,12 @@ function(con, name, value, field.types, row.names = TRUE,
 
    fn <- tempfile("rsdbi")
    fn <- gsub("\\\\", "/", fn)  # Since MySQL on Windows wants \ double (BDR)
-   safe.write(value, file = fn)
+   safe.write(value, file = fn, fileEncoding = "utf8")
    on.exit(unlink(fn), add = TRUE)
    sql4 <- paste("LOAD DATA LOCAL INFILE '", fn, "'",
-                  " INTO TABLE ", name, 
-                  " LINES TERMINATED BY '\n' ", 
+                  " INTO TABLE ", name,
+                  " CHARACTER SET utf8",
+                  " LINES TERMINATED BY '\n' ",
                   "( ", paste(names(field.types), collapse=", "), ");",
                sep="")
    rs <- try(dbSendQuery(con, sql4))


### PR DESCRIPTION
This addresses jeffreyhorner#6 since it ensures that encoding for writing
and reading the temporary file will always match and will be sufficient to
encode all Unicode codepoints so no information will get lost.

This change is untested (since I don't have the time to set up an R package building environment just now). And of course you are free to use a completely different solution, e.g. one avoiding the temporary file altogether.
