### PR TITLE
Patch to build with the latest mariadb MYSQL_SERVER_VERSION

### DIFF
--- a/src/RS-MySQL.h
+++ b/src/RS-MySQL.h
@@ -32,6 +32,11 @@ extern  "C" {
 #include <mysql_com.h>
 #include <string.h>
 
+// PATCH MARIA DB ==============================================================
+#if defined MARIADB_CLIENT_VERSION_STR && !defined MYSQL_SERVER_VERSION
+  #define MYSQL_SERVER_VERSION MARIADB_CLIENT_VERSION_STR
+#endif
+
 // Objects =====================================================================
 
 typedef struct RMySQLFields {


### PR DESCRIPTION
Patch to be compatible with latest mariadb as shown on:

https://wiki.gentoo.org/wiki/MariaDB#MYSQL_SERVER_VERSION