### PR TITLE
Honor brew prefix when hacking linker path

### DIFF
--- a/configure
+++ b/configure
@@ -33,8 +33,8 @@ elif [ "$PKGCONFIG_CFLAGS" ] || [ "$PKGCONFIG_LIBS" ]; then
   PKG_CFLAGS=${PKGCONFIG_CFLAGS}
   PKG_LIBS=${PKGCONFIG_LIBS}
   # Workaround for homebrew linkin bug
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    PKG_LIBS="-L/usr/local/opt/openssl/lib $PKG_LIBS"
+  if [[ "$OSTYPE" == "darwin"* && -n "$(command -v brew)" ]]; then
+    PKG_LIBS="-L$(brew --prefix)/opt/openssl/lib $PKG_LIBS"
   fi
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   if [ $(command -v brew) ]; then


### PR DESCRIPTION
This package was failing to install for me because I'm using a custom brew prefix. We already honor the prefix further down, so we should do it here too.