### PR TITLE
fix immediate parameter error in dbplyr::dbExecute

### DIFF
--- a/R/result.R
+++ b/R/result.R
@@ -93,7 +93,7 @@ setMethod("fetch", c("MySQLResult", "missing"), function(res, n, ...) {
 #' @export
 #' @useDynLib RMySQL RS_MySQL_exec
 setMethod("dbSendQuery", c("MySQLConnection", "character"),
-  function(conn, statement) {
+  function(conn, statement, ...) {
     checkValid(conn)
 
     rsId <- .Call(RS_MySQL_exec, conn@Id, as.character(statement))

--- a/man/query.Rd
+++ b/man/query.Rd
@@ -20,7 +20,7 @@
 
 \S4method{fetch}{MySQLResult,missing}(res, n = -1, ...)
 
-\S4method{dbSendQuery}{MySQLConnection,character}(conn, statement)
+\S4method{dbSendQuery}{MySQLConnection,character}(conn, statement, ...)
 
 \S4method{dbClearResult}{MySQLResult}(res, ...)
 


### PR DESCRIPTION
Because `dbplyr::dbExecute` has an additional parameter `immediate`, which will further pass to `dbSendQuery`, and lead to RMySQL broken.

I added `...` to `dbSendQuery.MySQLConnection`, which will ignore `immediate` and any other irrelevant parameters, and make RMySQL in dbplyr alive again. 

Hope this PR could be accepted. Thanks.
<https://github.com/tidyverse/dbplyr/blob/1e48cfaf795f9101792567bc68ce7d24a19db9d5/R/rows.R#L767>